### PR TITLE
Change default values for number of connections in CQL benchmarks.

### DIFF
--- a/yugabyteCQL/README.md
+++ b/yugabyteCQL/README.md
@@ -98,6 +98,7 @@ bin/ycsb run yugabyteCQL -P yugabyteCQL/db.properties -P workloads/workloada
 * `cassandra.maxconnections`
 * `cassandra.coreconnections`
   * Defaults for max and core connections can be found here: https://datastax.github.io/java-driver/2.1.8/features/pooling/#pool-size. Cassandra 2.0.X falls under protocol V2, Cassandra 2.1+ falls under protocol V3.
+  A lower value for these cause a bottleneck with the network thread and hence we would prefer a higher value for these.
 * `cassandra.connecttimeoutmillis`
 * `cassandra.useSSL`
   * Default value is false.

--- a/yugabyteCQL/db.properties
+++ b/yugabyteCQL/db.properties
@@ -17,3 +17,5 @@
 hosts=127.0.0.1
 port=9042
 cassandra.username=yugabyte
+cassandra.maxconnections=2
+cassandra.coreconnections=2


### PR DESCRIPTION
Summary:
With the v3 version of the driver the number of connections we use is 1.
This causes bootlenecks in the reactor thread leading to lower
performance.

Solution is to increase those numbers to increase performance.

Reviewers: Karthik, Kannan