### PR TITLE
Allow compilation of YugabyteCQL and YugabyteSQL generically.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -282,6 +282,18 @@ LICENSE file.
        <version>${project.version}</version>
      </dependency>
 
+    <dependency>
+       <groupId>site.ycsb</groupId>
+       <artifactId>yugabyteCQL-binding</artifactId>
+       <version>${project.version}</version>
+     </dependency>
+
+    <dependency>
+       <groupId>site.ycsb</groupId>
+       <artifactId>yugabyteSQL-binding</artifactId>
+       <version>${project.version}</version>
+     </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/yugabyteCQL/pom.xml
+++ b/yugabyteCQL/pom.xml
@@ -28,7 +28,7 @@ LICENSE file.
   </parent>
 
   <artifactId>yugabyteCQL-binding</artifactId>
-  <name>Cassandra 2.1+ DB Binding</name>
+  <name>Yugabyte Cassandra 2.1+ DB Binding</name>
   <packaging>jar</packaging>
 
   <properties>

--- a/yugabyteSQL/pom.xml
+++ b/yugabyteSQL/pom.xml
@@ -25,7 +25,7 @@ LICENSE file.
     <relativePath>../binding-parent</relativePath>
   </parent>
   <artifactId>yugabyteSQL-binding</artifactId>
-  <name>JDBC DB Binding</name>
+  <name>Yugabyte JDBC DB Binding</name>
   <packaging>jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
Summary:
Currently YugabyteCQL and YugabyteSQL bindings are compiled when we give
the '-pl' option to maven. However, they don't compile when we compile
the entire package.

This change fixes that.

Reviewers: Karthik