### PR TITLE
Use python2 from environment when calling YCSB

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2012 - 2015 YCSB contributors. All rights reserved.
 #


### PR DESCRIPTION
When running local ptests, the environment will be in a python3 virtualenv. The current YCSB python code is not python3 compatible, so for now, just include the python version in the shebang.